### PR TITLE
Explicitly reference FlurrySDK 9.3.0 on iOS.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,7 +28,7 @@
         <!--<header-file src="src/ios/Flurry.h" />-->
         <header-file src="src/ios/FlurryAnalyticsPlugin.h"/>
         <source-file src="src/ios/FlurryAnalyticsPlugin.m"/>
-        <pod id="Flurry-iOS-SDK/FlurrySDK"/>
+        <pod id="Flurry-iOS-SDK/FlurrySDK" spec="9.3.0"/>
     </platform>
 
     <platform name="android">


### PR DESCRIPTION
The plugin is currently incompatible with FlurrySDK version 10+ so we need to explicitly reference an older version of FlurrySDK to prevent broken builds.